### PR TITLE
Add countdown to enlightenment status page

### DIFF
--- a/port/wasm/enlightenment/src/components/CountdownTimer.vue
+++ b/port/wasm/enlightenment/src/components/CountdownTimer.vue
@@ -1,0 +1,52 @@
+<template>
+  <template v-if="days > 0">
+    {{ days }}:{{ hours.toString().padStart(2, "0") }}:{{ minutes.toString().padStart(2, "0") }}:{{
+      seconds.toString().padStart(2, "0")
+    }}
+  </template>
+  <template v-else>
+    {{ hours }}:{{ minutes.toString().padStart(2, "0") }}:{{ seconds.toString().padStart(2, "0") }}
+  </template>
+</template>
+
+<script>
+export default {
+  props: {
+    deadline: Number,
+  },
+  data() {
+    let remainingSeconds = this.deadline - Date.now() / 1000;
+    if (remainingSeconds < 0) {
+      remainingSeconds = 0;
+    }
+    return {
+      remainingSeconds,
+    };
+  },
+  mounted() {
+    const intervalId = setInterval(() => {
+      const remainingSeconds = this.deadline - Date.now() / 1000;
+      if (remainingSeconds < 0) {
+        this.remainingSeconds = 0;
+        clearInterval(intervalId);
+      } else {
+        this.remainingSeconds = remainingSeconds;
+      }
+    }, 200);
+  },
+  computed: {
+    days() {
+      return Math.floor(this.remainingSeconds / 86400);
+    },
+    hours() {
+      return Math.floor(this.remainingSeconds / 3600) % 24;
+    },
+    minutes() {
+      return Math.floor(this.remainingSeconds / 60) % 60;
+    },
+    seconds() {
+      return Math.floor(this.remainingSeconds) % 60;
+    },
+  },
+};
+</script>

--- a/port/wasm/enlightenment/src/components/TheCompanion.vue
+++ b/port/wasm/enlightenment/src/components/TheCompanion.vue
@@ -62,6 +62,13 @@
         </span>
       </p>
 
+      <p v-if="!completed" class="text-sm">
+        Current Time Left:
+        <span class="text-green-500 whitespace-nowrap">
+          <countdown-timer :deadline="currentCompletionTimeleft"></countdown-timer>
+        </span>
+      </p>
+
       <hr class="mt-2" />
 
       <section class="my-2 text-sm">
@@ -137,6 +144,7 @@ import { computed, defineComponent, onBeforeUnmount, ref } from "vue";
 import dayjs, { Dayjs } from "dayjs";
 import localizedFormat from "dayjs/plugin/localizedFormat";
 import relativeTime from "dayjs/plugin/relativeTime";
+import CountdownTimer from "./CountdownTimer.vue";
 
 import {
   eggIconPath,
@@ -163,6 +171,7 @@ export default defineComponent({
     ArtifactsGallery,
     UnfinishedResearches,
     BaseInfo,
+    CountdownTimer,
   },
   props: {
     playerId: {
@@ -233,17 +242,20 @@ export default defineComponent({
     const lastRefreshedPopulation = farm.numChickens! as number;
     const targetPopulation = 1e10;
     const completed = lastRefreshedPopulation >= targetPopulation;
-    let completionForecast: Dayjs | undefined;
-    if (!completed && offlineIHR > 0) {
-      const timeToCompleteSeconds =
-        ((targetPopulation - lastRefreshedPopulation) / offlineIHR) * 60;
-      completionForecast = dayjs(lastRefreshedTimestamp + timeToCompleteSeconds * 1000);
-    }
     const currentPopulation = computed(
       () =>
         lastRefreshedPopulation +
         (offlineIHR / 60_000) * (currentTimestamp.value - lastRefreshedTimestamp)
     );
+    let completionForecast: Dayjs | undefined;
+    let currentCompletionTimeleft: number | undefined;
+    if (!completed && offlineIHR > 0) {
+      const timeToCompleteSeconds =
+        ((targetPopulation - lastRefreshedPopulation) / offlineIHR) * 60;
+      completionForecast = dayjs(lastRefreshedTimestamp + timeToCompleteSeconds * 1000);
+      currentCompletionTimeleft = 
+        (((targetPopulation - currentPopulation.value) / offlineIHR * 60) * 1000 + currentTimestamp.value) / 1000;
+    }
 
     return {
       nickname,
@@ -270,6 +282,7 @@ export default defineComponent({
       completionForecast,
       formatWithThousandSeparators,
       iconURL,
+      currentCompletionTimeleft,
     };
   },
 });


### PR DESCRIPTION
I just copied the countdown plugin from the rocket tracker. I can move to a common folder if there is one. 

Found the status page and I like to see a countdown. 